### PR TITLE
Added support for save, save-dev and prefix flags.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+
+node_js:
+  - "0.10"
+  - "0.12"
+  - iojs
+
+before_install:
+  - npm config set spin false
+  - npm install -g npm@^2
+  - npm install -g mocha

--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ module.exports = {
     return doNpmCommand({
       npmCommand: 'install',
       cmdArgs: options.dependencies,
+      save: options.save || false,
+      saveDev: options.saveDev || false,
       cmdOptions: {
         production: options.production || false,
         loglevel: options.loglevel || undefined
@@ -70,6 +72,15 @@ function doNpmCommand(options, cb) {
     cmd += 'npm ' + options.npmCommand + ' ';
     cmd += options.cmdArgs.join(' ');
     cmd += ' ';
+
+    if ('save' in options && options.save) {
+        cmd += '--save ';
+    }
+
+    if ('saveDev' in options && options.saveDev) {
+      cmd += '--save-dev ';
+    }
+
     for (var key in options.cmdOptions) {
       // Skip undefined options
       if (options.cmdOptions[key] !== undefined) {

--- a/index.js
+++ b/index.js
@@ -21,12 +21,12 @@ module.exports = {
     return doNpmCommand({
       npmCommand: 'install',
       cmdArgs: options.dependencies,
-      save: options.save || false,
-      saveDev: options.saveDev || false,
-      path: options.path || '',
       cmdOptions: {
         production: options.production || false,
-        loglevel: options.loglevel || undefined
+        loglevel: options.loglevel || undefined,
+        save: options.save || false,
+        'save-dev': options.saveDev || false,
+        prefix: options.prefix || undefined,
       }
     }, cb);
   },
@@ -41,7 +41,11 @@ module.exports = {
       npmCommand: 'update',
       path: options.path || '',
       cmdArgs: [],
-      cmdOptions: options.cmdOptions
+      cmdOptions: {
+        production: options.production || false,
+        loglevel: options.loglevel || undefined,
+        prefix: options.prefix || undefined,
+      }
     }, cb);
   }
 };
@@ -75,17 +79,17 @@ function doNpmCommand(options, cb) {
     cmd += options.cmdArgs.join(' ');
     cmd += ' ';
 
-    if ('save' in options && options.save) {
-        cmd += '--save ';
-    }
-
-    if ('saveDev' in options && options.saveDev) {
-      cmd += '--save-dev ';
-    }
-
-    if (options.path.length > 0) {
-      cmd += '--prefix ' + options.path + ' ';
-    }
+    // if ('save' in options && options.save) {
+    //     cmd += '--save ';
+    // }
+    //
+    // if ('saveDev' in options && options.saveDev) {
+    //   cmd += '--save-dev ';
+    // }
+    //
+    // if (options.path.length > 0) {
+    //   cmd += '--prefix ' + options.path + ' ';
+    // }
 
     for (var key in options.cmdOptions) {
       // Skip undefined options

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ module.exports = {
       cmdArgs: options.dependencies,
       save: options.save || false,
       saveDev: options.saveDev || false,
+      path: options.path || '',
       cmdOptions: {
         production: options.production || false,
         loglevel: options.loglevel || undefined
@@ -38,6 +39,7 @@ module.exports = {
   update: function(options, cb) {
     return doNpmCommand({
       npmCommand: 'update',
+      path: options.path || '',
       cmdArgs: [],
       cmdOptions: options.cmdOptions
     }, cb);
@@ -79,6 +81,10 @@ function doNpmCommand(options, cb) {
 
     if ('saveDev' in options && options.saveDev) {
       cmd += '--save-dev ';
+    }
+
+    if (options.path.length > 0) {
+      cmd += '--prefix ' + options.path + ' ';
     }
 
     for (var key in options.cmdOptions) {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "homepage": "https://github.com/mikermcneil/enpeem",
   "dependencies": {
-    "stream-reduce": "1.0.1"
+    "stream-reduce": "1.0.3"
   },
   "devDependencies": {
-    "fs-extra": "~0.8.1"
+    "fs-extra": "~0.16.3"
   }
 }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -99,7 +99,7 @@ describe('with save option', function (){
 });
 
 
-describe('with save-dev options', function (){
+describe('with save-dev option', function (){
 
 	function rimrafTestStuff (cb) {
 		this.pathToDep = path.resolve(
@@ -129,6 +129,36 @@ describe('with save-dev options', function (){
 		//require does not work because of caching
 		var devDependencies = JSON.parse(fs.readFileSync(this.pathToPackage), { encoding: 'utf8'}).devDependencies;
 		assert('string' in devDependencies);
+		fs.lstat(this.pathToDep, cb);
+	});
+});
+
+
+describe('with path option', function (){
+
+	function rimrafTestStuff (cb) {
+		this.pathToDep = path.resolve(
+			__dirname,
+			'../new-folder/node_modules/string');
+
+		fs.removeSync('new-folder');
+		exec('npm rm string --save-dev', cb);
+	}
+	before(rimrafTestStuff);
+	after(rimrafTestStuff);
+
+	it('should not crash', function(cb) {
+		npm.install({
+			dependencies: ['string'],
+			loglevel: 'silent',
+			production: false,
+			path: 'new-folder',
+			// 'min-cache': 999999999
+		}, cb);
+	});
+
+	it('should actually install things', function (cb) {
+		//require does not work because of caching
 		fs.lstat(this.pathToDep, cb);
 	});
 });

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,6 +1,8 @@
 var assert = require ('assert');
 var fs = require('fs-extra');
 var path = require('path');
+var exec = require('child_process').exec;
+// var execSync = require('child_process').execSync;
 
 describe('basic usage', function () {
 
@@ -35,7 +37,6 @@ describe('basic usage', function () {
 });
 
 
-
 describe('with more options', function (){
 
 	function rimrafTestStuff (cb) {
@@ -63,4 +64,71 @@ describe('with more options', function (){
 });
 
 
+describe('with save option', function (){
 
+	function rimrafTestStuff (cb) {
+		this.pathToDep = path.resolve(
+			__dirname,
+			'../node_modules/mocha');
+		this.pathToPackage = path.resolve(
+			__dirname, '../package.json'
+		);
+
+		//fs.remove(this.pathToDep, cb);
+		exec('npm rm mocha --save', cb);
+	}
+	before(rimrafTestStuff);
+	after(rimrafTestStuff);
+
+	it('should not crash', function(cb) {
+		this.npm.install({
+			dependencies: ['mocha'],
+			loglevel: 'silent',
+			production: false,
+			save: true
+			// 'min-cache': 999999999
+		}, cb);
+	});
+
+	it('should actually install things', function (cb) {
+		//require does not work because of caching
+		var dependencies = JSON.parse(fs.readFileSync(this.pathToPackage), { encoding: 'utf8'}).dependencies;
+		assert('mocha' in dependencies);
+		fs.lstat(this.pathToDep, cb);
+	});
+});
+
+
+describe('with save-dev options', function (){
+
+	function rimrafTestStuff (cb) {
+		this.pathToDep = path.resolve(
+			__dirname,
+			'../node_modules/string');
+		this.pathToPackage = path.resolve(
+			__dirname, '../package.json'
+		);
+
+		//fs.remove(this.pathToDep, cb);
+		exec('npm rm string --save-dev', cb);
+	}
+	before(rimrafTestStuff);
+	after(rimrafTestStuff);
+
+	it('should not crash', function(cb) {
+		this.npm.install({
+			dependencies: ['string'],
+			loglevel: 'silent',
+			production: false,
+			saveDev: true,
+			// 'min-cache': 999999999
+		}, cb);
+	});
+
+	it('should actually install things', function (cb) {
+		//require does not work because of caching
+		var devDependencies = JSON.parse(fs.readFileSync(this.pathToPackage), { encoding: 'utf8'}).devDependencies;
+		assert('string' in devDependencies);
+		fs.lstat(this.pathToDep, cb);
+	});
+});

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -152,7 +152,7 @@ describe('with path option', function (){
 			dependencies: ['string'],
 			loglevel: 'silent',
 			production: false,
-			path: 'new-folder',
+			prefix: 'new-folder',
 			// 'min-cache': 999999999
 		}, cb);
 	});

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -2,7 +2,7 @@ var assert = require ('assert');
 var fs = require('fs-extra');
 var path = require('path');
 var exec = require('child_process').exec;
-// var execSync = require('child_process').execSync;
+var npm = require('../');
 
 describe('basic usage', function () {
 
@@ -50,7 +50,7 @@ describe('with more options', function (){
 	after(rimrafTestStuff);
 
   it('should not crash', function(cb) {
-    this.npm.install({
+    npm.install({
       dependencies: ['mocha'],
       loglevel: 'silent',
       production: true,
@@ -81,7 +81,7 @@ describe('with save option', function (){
 	after(rimrafTestStuff);
 
 	it('should not crash', function(cb) {
-		this.npm.install({
+		npm.install({
 			dependencies: ['mocha'],
 			loglevel: 'silent',
 			production: false,
@@ -116,7 +116,7 @@ describe('with save-dev options', function (){
 	after(rimrafTestStuff);
 
 	it('should not crash', function(cb) {
-		this.npm.install({
+		npm.install({
 			dependencies: ['string'],
 			loglevel: 'silent',
 			production: false,


### PR DESCRIPTION
Added two now properties `save: true/false` as well as `saveDev: true/false` which simply adds `--save` or `--save-dev` to the command.

Also updated dependencies and tests. This is needed for my [machinepack-npm](https://github.com/mikermcneil/machinepack-npm) implementation of installPackage/updatePackage.

Let me know if that seems fine to merge.
