### PR TITLE
added link command

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,22 @@ module.exports = {
   },
 
   /**
+   * Link locallay (or globally) a NPM package
+   * @param  {[type]}   options [description]
+   * @param  {Function} cb      [description]
+   * @return {[type]}           [description]
+   */
+  link: function(options, cb) {
+    return doNpmCommand({
+      npmCommand: 'link',
+      cmdArgs: options.dependencies,
+      cmdOptions: {
+        loglevel: options.loglevel || undefined
+      }
+    }, cb);
+  },
+
+  /**
    * @param  {[type]}   options      [description]
    * @param  {Function} cb           [description]
    * @return {[type]}                [description]

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ module.exports = {
   link: function(options, cb) {
     return doNpmCommand({
       npmCommand: 'link',
+      scope: options.scope || undefined,
       cmdArgs: options.dependencies,
       cmdOptions: {
         loglevel: options.loglevel || undefined
@@ -118,6 +119,10 @@ function doNpmCommand(options, cb) {
     // DRY:
     // console.log('WOULD HAVE RUN::');
     // console.log(cmd);
+
+    // Setup the scope
+    if (options.scope)
+      process.chdir(options.scope);
 
     // Spin up child process
     var npm = exec(cmd);


### PR DESCRIPTION
Useful for link a package as global in your system or link locally a global package.

Based in the documentation of the command:

```
npm link (in package folder)
npm link [@<scope>/]<pkgname>
npm ln (with any of the previous argument usage)
```

For cover all cases can be necessary a `scope` param for specify the `process.cwd` path, but I'm not sure if you are using `options.path` at this moment for do something like this.

Anyway we can add something like if is present change the scope with `process.chdir`, exec the command and revert the `process.cwd` scope as behavior inside `doNpmCommand` function.

What do you think? :-)
